### PR TITLE
feature/remove full rd enum

### DIFF
--- a/src/Bitmovin/api/enum/codecConfigurations/H264SubMe.php
+++ b/src/Bitmovin/api/enum/codecConfigurations/H264SubMe.php
@@ -18,6 +18,5 @@ class H264SubMe extends AbstractEnum
     const RD_REF_IP = 'RD_REF_IP';
     const RD_REF_ALL = 'RD_REF_ALL';
     const QPRD = 'QPRD';
-    const FULL_RD = 'FULL_RD';
 
 }


### PR DESCRIPTION
FULL_RD slows down H264 encodes by 40% and does not improve quality.